### PR TITLE
Make the body parser limit configurable

### DIFF
--- a/lib/webapi.js
+++ b/lib/webapi.js
@@ -19,6 +19,7 @@ export class WebAPI {
         this.port = opts.http_port || 80;
         this.routes = opts.routes;
         this.log = opts.debug?.bound("http") ?? console.log;
+        this.body_limit = opts.body_limit || "100kb";
 
         this.auth = new FplusHttpAuth({
             ...opts,
@@ -35,8 +36,8 @@ export class WebAPI {
 
         /* Body decoders. These will only decode request bodies of the
          * appropriate content-type. */
-        app.use(express.json());
-        app.use(express.text());
+        app.use(express.json({ limit: this.body_limit }));
+        app.use(express.text({ limit: this.body_limit }));
 
         /* Logging */
         app.use((req, res, next) => {


### PR DESCRIPTION
We are needing to send some very large entries to the ConfigDB.